### PR TITLE
Use proper nesting for observers

### DIFF
--- a/mentor_assistant.R
+++ b/mentor_assistant.R
@@ -87,15 +87,13 @@ server <- function(input, output, session) {
                                          input$frustration)
       # Use chat to process the prompt
       stream <- chat$stream_async(prompt)
-      chat_append("chat", stream)
-      
-      observeEvent(input$chat_user_input, {
-         stream <- chat$stream_async(input$chat_user_input)
-         chat_append("chat", stream)
-      })
-      
+      chat_append("chat", stream)      
    })
-   
+
+   observeEvent(input$chat_user_input, {
+      stream <- chat$stream_async(input$chat_user_input)
+      chat_append("chat", stream)
+   })   
 }
 
 shinyApp(ui, server)


### PR DESCRIPTION
With the second observeEvent nested inside the first observeEvent, it means the second observeEvent will be created multiple times--once each time the "Generate Prompt" is run. You can see this if you press Generate Prompt, wait for it to respond, press Generate Prompt again, wait for it to respond; and then type something into the chat input. You'll see that you actually get two responses intertwined. This change should fix that.